### PR TITLE
Update Dell warranty check for v4 API; Add warranty_start for Dell warranty

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This module provides additional warranty facts.
 Supported Manufacturers
 
 * Dell
-* Lenovo
+* Lenovo (no warranty_start support yet)
 
 Please contribute with for more manufacturers.
 
@@ -13,6 +13,7 @@ Facts
 ---
     warranty => true
     warranty_expiration => 2013-11-05
+    warranty_start => 2011-11-05
 
 How?
 ---

--- a/README.md
+++ b/README.md
@@ -17,5 +17,4 @@ Facts
 
 How?
 ---
-Warranty checks are being made against manufacturers website. The result get cached locally for 24 hours.
-
+Warranty checks are being made against manufacturers website. The result get cached locally for 24 hours. You must obtain an API key from Dell via [TechDirect](https://techdirect.dell.com/certification/AboutAPIs.aspx).

--- a/lib/facter/warranty.rb
+++ b/lib/facter/warranty.rb
@@ -57,7 +57,7 @@ def create_dell_warranty_cache(cache)
 
       new_expiration_date = Time.parse(h['EndDate'])
       Facter.debug("warranty new_expiration_date : " + new_expiration_date.inspect)
-      if expiration_date < new_expiration_date 
+      if expiration_date < new_expiration_date
         expiration_date = new_expiration_date
         Facter.debug("warranty expiration_date updated to new_expiration_date : " + expiration_date.inspect)
       end
@@ -66,7 +66,7 @@ def create_dell_warranty_cache(cache)
       new_start_date = Time.parse(h['StartDate'])
       Facter.debug("warranty new_start_date : " + new_start_date.inspect)
       if new_start_date < start_date
-        start_date = new_start_date 
+        start_date = new_start_date
         Facter.debug("warranty start_date updated to new_start_date : " + start_date.inspect)
       end
     end


### PR DESCRIPTION
This is a bit hacky as it was done as fast as possible, but the Dell v2 API keys no longer work and the only way to use the warranty API now is via the newer v4 API calls.  You need to request a key for this to work, so I've just made this patch read it from a file (obviously could be any different path).

Also added warranty_start fact, as we needed this for reporting the start date of the warranty on hosts.

The filtering for ServiceLevelGroups being set to 5 is because that's what the hardware warranties appear to be set to.

Overall this needs more testing but I thought I'd make a pull request as this is working OK for us :)